### PR TITLE
Add a configuration for gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,8 @@
+---
+image:
+  file: Dockerfile
+vscode:
+  extensions:
+    - ms-azuretools.vscode-docker
+    - ms-python.python
+    - ms-vscode.makefile-tools

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM registry.opensuse.org/opensuse/tumbleweed:latest
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# hadolint ignore=DL3004
+RUN zypper -n in system-group-wheel sudo make podman git jq sed python3 && zypper -n clean
+
+### Gitpod user ###
+# '-l': see https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user
+
+# hadolint ignore=DL3004
+RUN groupadd -g 33333 gitpod && \
+    useradd -l -u 33333 -g 33333 -G wheel -md /home/gitpod -s /bin/bash -p gitpod gitpod && \
+    # passwordless sudo for users in the 'wheel' group
+    echo "%wheel ALL=(ALL) NOPASSWD: ALL" | tee -a /etc/sudoers.d/00-wheel-group-nopasswd
+
+ENV HOME=/home/gitpod
+WORKDIR $HOME
+USER gitpod
+# custom Bash prompt
+RUN { echo && echo ". /etc/bash_completion.d/git-prompt.sh" && echo "PS1='\[\033[01;32m\]\u\[\033[00m\] \[\033[01;34m\]\w\[\033[00m\]\$(__git_ps1 \" (%s)\") $ '" ; } >> .bashrc
+
+### Gitpod user (2) ###
+# use sudo so that user does not get sudo usage info on (the first) login
+# hadolint ignore=DL3004
+RUN sudo echo "Running 'sudo' for Gitpod: success" && \
+    # create .bashrc.d folder and source it in the bashrc
+    mkdir -p /home/gitpod/.bashrc.d && \
+    (echo; echo "for i in \$(ls -A \$HOME/.bashrc.d/); do source \$HOME/.bashrc.d/\$i; done"; echo) >> /home/gitpod/.bashrc

--- a/README.md
+++ b/README.md
@@ -70,3 +70,8 @@ LABEL statements can be created from an existing image by running:
 `podman image inspect foo | jq '.[0]["Config"]["Labels"]' | sed 's/": /=/g;s/^  "/LABEL /g;s/,$//g'`
 
 Run `make test` (or just `make tests/foo/tested`) to see the output and `make test-regen` (or just `make tests/foo/regen`) to save it as `checks.out`.
+
+Editing in Gitpod
+==================
+
+You can apply your edits directly from within your browser on [Gitpod](https://gitpod.io/#https://github.com/openSUSE/container-build-checks).


### PR DESCRIPTION
Add a configuration file improving the user experience when using gitpod.io (= vscode in a browser) to contribute to container-build-checks.